### PR TITLE
refactor: set input keyboard control

### DIFF
--- a/src/vue-number-format.vue
+++ b/src/vue-number-format.vue
@@ -1,7 +1,7 @@
 <template>
   <input
     :value="formattedValue"
-    type="tel"
+    inputmode="numeric"
     @input="onInput($event)"
     @focus="onFocus($event)"
   >
@@ -61,7 +61,7 @@ export default {
         this.$emit('update:value', value)
       }
     }
-    
+
   }
 }
 </script>


### PR DESCRIPTION
`type="tel"` will show number keyboard for mobile user and make browser understand the input is a field for telephone number, imo is better replace it to `inputmode="numeric"` to change only the input keyboard and make the content of input generic